### PR TITLE
Sc 22/remove anchors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,13 @@
 version: 2
 
-anchors:
-  default-config: &default-config
+updates:
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: dependabot-base
-
-updates:
-  - package-ecosystem: "gomod"
-    <<: *default-config
   - package-ecosystem: "github-actions"
-    <<: *default-config
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: dependabot-base

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: git config --global user.email tristan@github-action.com
+      - run: git config --global user.email tristanehaffenden+github@gmail.com
       - run: git config --global user.name 'Tristan AutoTag'
       - run: make push-tag
       - run: git fetch --force --tags


### PR DESCRIPTION
## Problem

I didn't actually validate the dependabot config change. Turns out it doens't like anchors.

## Solution

Remove yaml anchors.
Release config was also failing, due to the tag protection rule added, so update the email used to create the tag to see if that fixes it.

## Notes
